### PR TITLE
feat CLI: pipes and substitutions support

### DIFF
--- a/core/include/cat_command.hpp
+++ b/core/include/cat_command.hpp
@@ -19,4 +19,3 @@ class CatCommand final : public Command {
 };
 
 }  // namespace coreutils
-

--- a/core/include/echo_command.hpp
+++ b/core/include/echo_command.hpp
@@ -19,4 +19,3 @@ class EchoCommand final : public Command {
 };
 
 }  // namespace coreutils
-

--- a/core/include/exit_command.hpp
+++ b/core/include/exit_command.hpp
@@ -7,11 +7,10 @@ namespace coreutils {
 
 class ExitCommand final : public Command {
  public:
-  int run(Input& , Output& ) override {
+  int run(Input&, Output&) override {
     IsExit = true;
     return 0;
   }
 };
 
 }  // namespace coreutils
-

--- a/core/include/pwd_command.hpp
+++ b/core/include/pwd_command.hpp
@@ -10,4 +10,3 @@ class PwdCommand final : public Command {
 };
 
 }  // namespace coreutils
-

--- a/core/include/text_input.hpp
+++ b/core/include/text_input.hpp
@@ -12,8 +12,9 @@ class TextInput final : public Input {
  public:
   explicit TextInput(std::string str) {
     auto [in, out] = createPipe();
-    in_ = std::move(in);    // NOLINT
-    thread_.emplace([str = std::move(str), out = std::move(out)]() { out->write(str); });
+    in_ = std::move(in);  // NOLINT
+    thread_.emplace(
+        [str = std::move(str), out = std::move(out)]() { out->write(str); });
   }
   ~TextInput() override {
     in_.reset();

--- a/core/include/wc_command.hpp
+++ b/core/include/wc_command.hpp
@@ -9,14 +9,15 @@ namespace coreutils {
 
 class WcCommand final : public Command {
  public:
-  explicit WcCommand(std::vector<std::string> files)
-      : files_(std::move(files)) {}
+  explicit WcCommand(std::vector<std::string> args);
 
   int run(Input& in, Output& out) override;
 
  private:
   std::vector<std::string> files_;
+  bool count_lines_{false};
+  bool count_words_{false};
+  bool count_bytes_{false};
 };
 
 }  // namespace coreutils
-

--- a/core/src/cat_command.cpp
+++ b/core/src/cat_command.cpp
@@ -46,4 +46,3 @@ int CatCommand::run(Input& in, Output& out) {
 }
 
 }  // namespace coreutils
-

--- a/core/src/cli.cpp
+++ b/core/src/cli.cpp
@@ -1,6 +1,7 @@
 #include <cli.hpp>
 
 #include <unistd.h>
+#include <algorithm>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>

--- a/core/src/echo_command.cpp
+++ b/core/src/echo_command.cpp
@@ -21,4 +21,3 @@ int EchoCommand::run(Input& /*in*/, Output& out) {
 }
 
 }  // namespace coreutils
-

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1,18 +1,44 @@
 #include <executor.hpp>
 
 #include <cassert>
-#include <string>
 #include <vector>
 
 #include <command.hpp>
+#include <pipe.hpp>
 
 namespace coreutils {
 
 int Executor::runCommands(std::vector<CommandPtr> cmds, Input& in,
                           Output& out) {
-  // run 1 command
-  assert(cmds.size() == 1);
-  return cmds[0]->run(in, out);
+  assert(!cmds.empty());
+
+  if (cmds.size() == 1) {
+    return cmds[0]->run(in, out);
+  }
+
+  std::unique_ptr<Input> current_input;
+  Input* in_ptr = &in;
+
+  int exit_code = 0;
+
+  for (size_t i = 0; i < cmds.size(); ++i) {
+    const bool is_last_cmd = (i + 1 == cmds.size());
+
+    if (!is_last_cmd) {
+      // Пайп между cmd[i] и cmd[i+1]
+      auto [pipe_in, pipe_out] = createPipe();
+      exit_code = cmds[i]->run(*in_ptr, *pipe_out);
+
+      // cmd[i+1] будет читать из pipe_in
+      current_input = std::move(pipe_in);
+      in_ptr = current_input.get();
+    } else {
+      // Последняя команда пишет в out
+      exit_code = cmds[i]->run(*in_ptr, out);
+    }
+  }
+
+  return exit_code;
 }
 
 }  // namespace coreutils

--- a/core/src/input.cpp
+++ b/core/src/input.cpp
@@ -28,7 +28,7 @@ std::vector<char> Input::readVector() const {
     std::array<char, DEFAULT_BLOCK_SIZE> buf{};
     auto size = read(buf.data(), DEFAULT_BLOCK_SIZE);
     if (size == 0) {
-        return res;
+      return res;
     }
     res.insert(res.end(), buf.begin(), buf.begin() + size);
   }
@@ -46,14 +46,12 @@ std::string Input::readString() const {
     std::array<char, DEFAULT_BLOCK_SIZE> buf{};
     auto size = read(buf.data(), DEFAULT_BLOCK_SIZE);
     if (size == 0) {
-        return res;
+      return res;
     }
     res.insert(res.end(), buf.begin(), buf.begin() + size);
   }
 }
 
-void Input::setStdin() const {
-  dup2(fd(), STDIN_FILENO);
-}
+void Input::setStdin() const { dup2(fd(), STDIN_FILENO); }
 
 }  // namespace coreutils

--- a/core/src/output.cpp
+++ b/core/src/output.cpp
@@ -9,7 +9,7 @@ namespace coreutils {
 void Output::write(const char* data, size_t size) const {
   size_t written = 0;
   while (written != size) {
-    auto res = ::write(fd(), data + written, size - written); //NOLINT
+    auto res = ::write(fd(), data + written, size - written);  // NOLINT
     if (res == -1) {
       throw std::runtime_error("Write failed");
     }
@@ -25,8 +25,6 @@ void Output::write(const std::string& data) const {
   write(data.data(), data.size());
 }
 
-void Output::setStdout() const {
-  dup2(fd(), STDOUT_FILENO);
-}
+void Output::setStdout() const { dup2(fd(), STDOUT_FILENO); }
 
 }  // namespace coreutils

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -137,8 +137,6 @@ std::vector<std::string> Parser::parseToTokens(std::string&& raw_input) {
     if (in_single_quote) {
       if (ch == '\'') {
         in_single_quote = false;
-      } else if (ch == '$') {
-        handleDollarSign(raw_input, pos, current_token);
       } else {
         current_token += ch;
       }

--- a/core/src/pwd_command.cpp
+++ b/core/src/pwd_command.cpp
@@ -13,4 +13,3 @@ int PwdCommand::run(Input& /*in*/, Output& out) {
 }
 
 }  // namespace coreutils
-

--- a/core/src/wc_command.cpp
+++ b/core/src/wc_command.cpp
@@ -49,19 +49,55 @@ struct FileStats {
   return stats;
 }
 
-std::string toString(const FileStats& stats) {
-  return std::to_string(stats.lines) + " " + std::to_string(stats.words) + " " +
-         std::to_string(stats.bytes);
+std::string toString(const FileStats& stats, bool lines, bool words,
+                     bool bytes) {
+  std::string result;
+  constexpr int kFieldWidth = 8;
+
+  if (lines) {
+    std::string line_str = std::to_string(stats.lines);
+    result += std::string(kFieldWidth - line_str.length(), ' ') + line_str;
+  }
+  if (words) {
+    std::string word_str = std::to_string(stats.words);
+    result += std::string(kFieldWidth - word_str.length(), ' ') + word_str;
+  }
+  if (bytes) {
+    std::string byte_str = std::to_string(stats.bytes);
+    result += std::string(kFieldWidth - byte_str.length(), ' ') + byte_str;
+  }
+  return result;
 }
 
 }  // namespace
+
+WcCommand::WcCommand(std::vector<std::string> args) {
+  for (const auto& arg : args) {
+    if (arg == "-l") {
+      count_lines_ = true;
+    } else if (arg == "-w") {
+      count_words_ = true;
+    } else if (arg == "-c") {
+      count_bytes_ = true;
+    } else if (!arg.empty() && arg[0] != '-') {
+      files_.push_back(arg);
+    }
+  }
+
+  if (!count_lines_ && !count_words_ && !count_bytes_) {
+    count_lines_ = true;
+    count_words_ = true;
+    count_bytes_ = true;
+  }
+}
 
 int WcCommand::run(Input& in, Output& out) {
   if (files_.empty()) {
     FileStats stats =
         collectStats([&in](size_t size) { return in.readVector(size); });
 
-    auto result = toString(stats) + "\n";
+    auto result =
+        toString(stats, count_lines_, count_words_, count_bytes_) + "\n";
     out.write(result);
     return 0;
   }
@@ -80,7 +116,8 @@ int WcCommand::run(Input& in, Output& out) {
             buf.resize(stream.gcount());
             return buf;
           });
-      auto line = toString(stats) + " " + file + "\n";
+      auto line = toString(stats, count_lines_, count_words_, count_bytes_) +
+                  " " + file + "\n";
       out.write(line);
     } catch (const std::runtime_error&) {
       std::cerr << "Unable to open file: " << file << '\n';

--- a/test/cli_test.cpp
+++ b/test/cli_test.cpp
@@ -32,7 +32,7 @@ TEST_F(CLITest, RunCliSingleCommand) {
 
 TEST_F(CLITest, RunCliEnvVariables) {
   TextOutput output;
-  TextInput input("a=123 sh -c 'echo ${a}'");
+  TextInput input("a=123 echo ${a}");
   EXPECT_NO_THROW(cli->runCli(input, output));
   EXPECT_EQ(output.read(), "123\n");
 }

--- a/test/command_test.cpp
+++ b/test/command_test.cpp
@@ -66,7 +66,7 @@ TEST(CommandTest, WcReturnsFileStats) {
   TextOutput output;
 
   ASSERT_EQ(command.run(input, output), 0);
-  EXPECT_EQ(output.read(), "15 98 1039 " + file.string() + "\n");
+  EXPECT_EQ(output.read(), "      15      98    1039 " + file.string() + "\n");
 }
 
 TEST(CommandTest, WcReadInput) {
@@ -78,7 +78,7 @@ TEST(CommandTest, WcReadInput) {
   TextOutput output;
 
   ASSERT_EQ(command.run(input, output), 0);
-  EXPECT_EQ(output.read(), "15 98 1039\n");
+  EXPECT_EQ(output.read(), "      15      98    1039\n");
 }
 
 TEST(CommandTest, PwdPrintsCurrentWorkingDirectory) {
@@ -104,4 +104,3 @@ TEST(CommandTest, ExitCommandSetsExitFlag) {
 }
 
 }  // namespace coreutils::test
-

--- a/test/pipe_test.cpp
+++ b/test/pipe_test.cpp
@@ -1,6 +1,16 @@
 #include <pipe.hpp>
 
+#include <filesystem>
 #include <vector>
+
+#include <cat_command.hpp>
+#include <echo_command.hpp>
+#include <exit_command.hpp>
+#include <external_command.hpp>
+#include <global_state.hpp>
+#include <text_input.hpp>
+#include <text_output.hpp>
+#include <wc_command.hpp>
 
 #include <gtest/gtest.h>
 
@@ -14,6 +24,111 @@ TEST(Pipe, Basic) {
   EXPECT_EQ(in->readVector(DEFAULT_BLOCK_SIZE), expected);
   out.reset();
   EXPECT_EQ(in->readVector(DEFAULT_BLOCK_SIZE), std::vector<char>());
+}
+
+TEST(Pipe, EchoToWc) {
+  auto [in, out] = createPipe();
+
+  EchoCommand echo({"Hello", "World"});
+  WcCommand wc({});
+
+  TextInput dummy_in("");
+  TextOutput final_out;
+
+  ASSERT_EQ(echo.run(dummy_in, *out), 0);
+  out.reset();
+
+  ASSERT_EQ(wc.run(*in, final_out), 0);
+  EXPECT_EQ(final_out.read(), "       1       2      12\n");
+}
+
+TEST(Pipe, CatToWcWithFile) {
+  auto [in, out] = createPipe();
+
+  const auto file = std::filesystem::path(TEST_DATA_DIR) / "file.txt";
+  CatCommand cat({file.string()});
+  WcCommand wc({});
+
+  TextInput dummy_in("");
+  TextOutput final_out;
+
+  ASSERT_EQ(cat.run(dummy_in, *out), 0);
+  out.reset();
+
+  ASSERT_EQ(wc.run(*in, final_out), 0);
+  EXPECT_EQ(final_out.read(), "      15      98    1039\n");
+}
+
+TEST(Pipe, ExitInPipeline) {
+  auto [in, out] = createPipe();
+
+  IsExit = false;
+  ExitCommand exit_cmd;
+  EchoCommand echo({"test"});
+
+  TextInput dummy_in("");
+  TextOutput final_out;
+
+  ASSERT_EQ(exit_cmd.run(dummy_in, *out), 0);
+  EXPECT_TRUE(IsExit.load());
+  out.reset();
+
+  ASSERT_EQ(echo.run(*in, final_out), 0);
+
+  IsExit = false;
+}
+
+TEST(Pipe, NonZeroExitCode) {
+  auto [in, out] = createPipe();
+
+  ExternalCommand failing_cmd("cat", {"non_existent_file.txt"});
+  EchoCommand echo({"test"});
+
+  TextInput dummy_in("");
+  TextOutput final_out;
+
+  int exit_code = failing_cmd.run(dummy_in, *out);
+  EXPECT_NE(exit_code, 0);
+  out.reset();
+
+  ASSERT_EQ(echo.run(*in, final_out), 0);
+}
+
+TEST(Pipe, ThreeCommandPipeline) {
+  // echo "test data" | cat | wc
+  auto [in1, out1] = createPipe();
+  auto [in2, out2] = createPipe();
+
+  EchoCommand echo({"test", "data"});
+  CatCommand cat({});
+  WcCommand wc({});
+
+  TextInput dummy_in("");
+  TextOutput final_out;
+
+  // echo -> pipe1
+  ASSERT_EQ(echo.run(dummy_in, *out1), 0);
+  out1.reset();
+
+  // pipe1 -> cat -> pipe2
+  ASSERT_EQ(cat.run(*in1, *out2), 0);
+  out2.reset();
+
+  // pipe2 -> wc -> output
+  ASSERT_EQ(wc.run(*in2, final_out), 0);
+  EXPECT_EQ(final_out.read(), "       1       2      10\n");
+}
+
+TEST(Pipe, EmptyPipelineInput) {
+  auto [in, out] = createPipe();
+
+  out.reset();
+
+  WcCommand wc({});
+  TextOutput final_out;
+
+  ASSERT_EQ(wc.run(*in, final_out), 0);
+  EXPECT_EQ(final_out.read(), "       0       0       0\n");
 }
 
 }  // namespace coreutils::test


### PR DESCRIPTION
- Поддержана возможность составлять пайплайн из команд (оператор "|")
- Поддержана разная логика работы одинарных и двойных кавычек (внутри одинарных не выполняем подстановку)
- На новую функциональность написаны тесты
- Исправлены небольшие баги